### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.12
-anndata==0.80
+anndata==0.8.0
 cmake==3.22.3
 Cython==0.29
 h5py==3.6


### PR DESCRIPTION
BEFORE:
```
/Users/andrew/SEACells % pip install -r requirements.txt
ERROR: Could not find a version that satisfies the requirement anndata==0.80 (from versions: 0.1, 0.2, 0.2.1, 0.3, 0.3.0.1, 0.3.0.2, 0.3.0.3, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.4, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.5, 0.5.1, 0.5.2, 0.5.3, 0.5.4, 0.5.5, 0.5.6, 0.5.7, 0.5.8, 0.5.8.post1, 0.5.9, 0.5.10, 0.5.10.post1, 0.5.10.post2, 0.6, 0.6.1, 0.6.2, 0.6.3, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 0.6.8, 0.6.9, 0.6.10, 0.6.11, 0.6.12, 0.6.13, 0.6.14, 0.6.15, 0.6.16, 0.6.17, 0.6.18, 0.6.19, 0.6.20, 0.6.21, 0.6.22rc1, 0.6.22, 0.6.22.post1, 0.7rc1, 0.7rc2, 0.7, 0.7.1, 0.7.2a1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.8.0rc1, 0.8.0, 0.9.0rc1, 0.9.0, 0.9.1, 0.9.2)
ERROR: No matching distribution found for anndata==0.80
```

AFTER:
```
/Users/andrew/SEACells % pip install -r requirements.txt
DEPRECATION: Loading egg at /opt/homebrew/anaconda3/lib/python3.11/site-packages/palantir-1.3.0-py3.11.egg is deprecated. pip 23.3 will enforce this behaviour change. A possible replacement is to use pip for package installation..
...
Collecting anndata==0.8.0 (from -r requirements.txt (line 2))
  Downloading anndata-0.8.0-py3-none-any.whl (96 kB)
```