### PR TITLE
requirements.txt file contains incorrect versions numbers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 alabaster==0.7.12
-anndata==0.80
+anndata==0.8.0
 cmake==3.22.3
 Cython==0.29
 h5py==3.6
 joblib==1.2.0
 kiwisolver==1.3.2
-legacy-api-wrap==0.0.0
+legacy-api-wrap==1.0
 leidenalg==0.8.9
 llvmlite==0.38.0
 louvain==0.7.1


### PR DESCRIPTION
fix(requirements): Fixed the requirements.txt versions preventing installation.

It is unclear what version `legacy-api-wrap` is as it was set as `0.0.0`
`anndata` was written as `0.80` (presumed `0.8.0`)