### PR TITLE
import `genescores` module in __init__.py

### DIFF
--- a/SEACells/__init__.py
+++ b/SEACells/__init__.py
@@ -1,5 +1,6 @@
 from . import core
 from . import preprocess
+from . import genescores
 from . import utils
 from . import plot
 from .version import __version__


### PR DESCRIPTION
Adds import statement for the `genescores` module to address settylab/atac_metacell_utilities#17, where `SEACells.genescores.get_gene_peak_correlations` is no longer available after importing SEACells.